### PR TITLE
Update to priority dispatch helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statengine/siamese",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Normalizes public safety data.",
   "main": "lib",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import CODES from './priorityDispatchCodes';
 
-const PRIORITY_DISPATCH_REGEX = /([0-9]+?)([ABCDEO])([0-9a-z]*)/;
-const SUBDETERMINATE_REGEX = /([0-9]+)([a-z]*)/;
+const PRIORITY_DISPATCH_REGEX = /([0-9]+?)([ABCDEO])([0-9a-zA-Z]*)/;
+const SUBDETERMINATE_REGEX = /([0-9]+)([a-zA-Z]*)/;
 
 function split(code) {
   /**
@@ -16,6 +16,7 @@ function split(code) {
     return {};
   }
 
+  // [0] is fullMatch
   const [, protocol, determinate, subDeterminate] = check;
 
   return {
@@ -34,6 +35,7 @@ function getProtocolDescription(protocol) {
 
 function getSubDeterminateDescription(protocol, determinate, subDeterminate) {
   if (protocol && determinate && subDeterminate) {
+    // [0] is full match
     const [, noSuffix] = subDeterminate.toString().match(SUBDETERMINATE_REGEX);
     return _.get(CODES, `[${Number(protocol).toString()}]determinates[${determinate}]subdeterminants[${Number(noSuffix).toString()}.description]`);
   }

--- a/test/test.helpers.js
+++ b/test/test.helpers.js
@@ -17,6 +17,7 @@ describe('Helpers', () => {
         expect(helpers.priorityDispatch.getSubDeterminateDescription(1, 'A', 1)).to.equal('Abdominal pain');
         expect(helpers.priorityDispatch.getSubDeterminateDescription(1, 'A', '1')).to.equal('Abdominal pain');
         expect(helpers.priorityDispatch.getSubDeterminateDescription('01', 'A', '1a')).to.equal('Abdominal pain');
+        expect(helpers.priorityDispatch.getSubDeterminateDescription('01', 'A', '1A')).to.equal('Abdominal pain');
         expect(helpers.priorityDispatch.getSubDeterminateDescription('01', 'B', '1a')).to.be.undefined;
       });
 


### PR DESCRIPTION
Sometimes sub-determinate code will show up as follows `52C03G` original regex logic only looks for lowercase character regions for sub-determinate. Simple update to catch Uppercase characters that may be present.

Not necessarily the only reason DC category is failing, but it doesn't help because some cases fall through the original match logic because of uppercase characters.